### PR TITLE
Smash: Call `to_log` if it exists

### DIFF
--- a/lib/rumbrl/ext/hash.rb
+++ b/lib/rumbrl/ext/hash.rb
@@ -1,0 +1,8 @@
+# Extensions for native Hash to allow for log ingestion
+module HashExtensions
+  def to_log
+    to_hash
+  end
+end
+
+::Hash.include(HashExtensions)

--- a/lib/rumbrl/smash.rb
+++ b/lib/rumbrl/smash.rb
@@ -1,17 +1,18 @@
+require 'rumbrl/ext/hash'
+
 module Rumbrl
   # serializes & flattens hashes
   class Smash
     def self.flatten(target, namespace: '')
-      res = {}
-      target.each_pair do |k, v|
-        cur_nspace = build_namespace(namespace, k)
-        if v.is_a? Hash
-          res.update flatten(v, namespace: cur_nspace)
-          next
+      target.each_with_object({}) do |(k, v), res|
+        cur_namespace = build_namespace(namespace, k)
+
+        if v.respond_to?(:to_log)
+          res.update(flatten(v.to_log, namespace: cur_namespace))
+        else
+          res.update(cur_namespace.to_sym => v)
         end
-        res[cur_nspace.to_sym] = v
       end
-      res
     end
 
     def self.build_namespace(prev = '', cur = '')

--- a/spec/rumbrl/smash_spec.rb
+++ b/spec/rumbrl/smash_spec.rb
@@ -1,22 +1,55 @@
 require_relative '../spec_helper'
 
+# Mock class for testing
+class PopTart
+  def to_log
+    {
+      frosting: 'vanilla',
+      filling: 'strawberry'
+    }
+  end
+end
+
+class NotPopTart
+end
+
 describe Rumbrl::Smash do
   describe '.flatten' do
     it 'does not change flat hash' do
-      target = { bar: 'foo' }
-      expect(Rumbrl::Smash.flatten(target)).to eql target
+      source = { bar: 'foo' }
+      expect(Rumbrl::Smash.flatten(source)).to eql(source)
     end
 
     it 'flattens nested hashes with namespaced keys' do
-      target = { bar: 'foo', baz: { wee: 'boo' } }
-      flattened = { bar: 'foo', baz_wee: 'boo' }
-      expect(Rumbrl::Smash.flatten(target)).to eql flattened
+      source = { bar: 'foo', baz: { wee: 'boo' } }
+      target = { bar: 'foo', baz_wee: 'boo' }
+      expect(Rumbrl::Smash.flatten(source)).to eql(target)
     end
 
     it 'flattens nested hashes with mixed keys' do
-      target = { 'bar' => 'foo', baz: { 'wee' => 'boo' } }
-      flattened = { bar: 'foo', baz_wee: 'boo' }
-      expect(Rumbrl::Smash.flatten(target)).to eql flattened
+      source = { 'bar' => 'foo', baz: { 'wee' => 'boo' } }
+      target = { bar: 'foo', baz_wee: 'boo' }
+      expect(Rumbrl::Smash.flatten(source)).to eql(target)
+    end
+
+    context 'given an object' do
+      context 'that responds to `to_log`' do
+        it 'flattens hash representation of the object' do
+          source = { bar: 'foo', poptart: PopTart.new }
+          target = { bar: 'foo',
+                     poptart_frosting: 'vanilla',
+                     poptart_filling: 'strawberry' }
+          expect(Rumbrl::Smash.flatten(source)).to eql(target)
+        end
+      end
+
+      context 'that does not responds to `to_log`' do
+        it 'does not flatten the object' do
+          not_poptart = NotPopTart.new
+          source = { bar: 'foo', poptart: not_poptart }
+          expect(Rumbrl::Smash.flatten(source)).to eql(source)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This allows us to pass arbitrary objects into the logger and define what they should look like without requiring the caller of the log method to manually specify inclusions/exclusions.
